### PR TITLE
remove --persist and --reconnect, introduce --new. Default --new to t…

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -1365,7 +1365,7 @@ ${regression}
     if (this.instance) {
       this.emitter.emit(
         events.log.log,
-        theme.dim("Sandbox instance already exists, skipping buildEnv."),
+        theme.dim("- sandbox instance already exists, skipping launch."),
       );
       return;
     }
@@ -1389,7 +1389,7 @@ ${regression}
       if (!this.config.CI) {
         this.emitter.emit(
           events.log.log,
-          theme.dim("--new flag detected, will create a new sandbox"),
+          theme.dim("-- `new` flag detected, will create a new sandbox"),
         );
       }
     }
@@ -1409,7 +1409,7 @@ ${regression}
     } else if (!createNew) {
       this.emitter.emit(
         events.log.log,
-        theme.dim(`No recent sandbox found, creating a new one.`),
+        theme.dim(`- no recent sandbox found, creating a new one.`),
       );
     }
 
@@ -1609,6 +1609,7 @@ ${regression}
     let instance = await this.sandbox.send({
       type: "create",
       resolution: this.config.TD_RESOLUTION,
+      ci: this.config.CI,
     });
     return instance;
   }

--- a/agent/index.js
+++ b/agent/index.js
@@ -1399,16 +1399,14 @@ ${regression}
 
     const recentId = createNew ? null : this.getRecentSandboxId();
 
-    // Set up sandbox ID logic
-    if (createNew) {
-      // Skip any existing sandbox logic and go directly to new sandbox creation
-    } else if (recentId) {
+    // Set sandbox ID for reconnection (only if not creating new and recent ID exists)
+    if (!createNew && recentId) {
       this.emitter.emit(
         events.log.log,
         theme.dim(`- using recent sandbox: ${recentId}`),
       );
       this.sandboxId = recentId;
-    } else {
+    } else if (!createNew) {
       this.emitter.emit(
         events.log.log,
         theme.dim(`No recent sandbox found, creating a new one.`),

--- a/agent/index.js
+++ b/agent/index.js
@@ -1346,6 +1346,20 @@ ${regression}
       // ignore errors
     }
   }
+
+  clearRecentSandboxId() {
+    const lastSandboxFile = path.join(
+      os.homedir(),
+      ".testdriverai-last-sandbox",
+    );
+    try {
+      if (fs.existsSync(lastSandboxFile)) {
+        fs.unlinkSync(lastSandboxFile);
+      }
+    } catch {
+      // ignore errors
+    }
+  }
   async buildEnv(options = {}) {
     // If instance already exists, do not build environment again
     if (this.instance) {
@@ -1356,31 +1370,53 @@ ${regression}
       return;
     }
 
-    const { headless = false, heal, reconnect } = options;
+    let { headless = false, heal, new: createNew = false } = options;
+
+    // If CI environment variable is true, always create a new sandbox
+    if (this.config.CI) {
+      createNew = true;
+      this.emitter.emit(
+        events.log.log,
+        theme.dim("CI environment detected, will create a new sandbox"),
+      );
+    }
 
     if (heal) this.healMode = heal;
 
-    // order is important!
-    await this.connectToSandboxService();
-
-    const recentId = this.getRecentSandboxId();
-
-    if (reconnect) {
-      if (recentId) {
+    // If createNew flag is set, clear the recent sandbox file to force creating a new sandbox
+    if (createNew) {
+      this.clearRecentSandboxId();
+      if (!this.config.CI) {
         this.emitter.emit(
           events.log.log,
-          theme.dim(`- using recent sandbox: ${recentId}`),
-        );
-        this.sandboxId = recentId;
-      } else {
-        this.emitter.emit(
-          events.log.warn,
-          theme.yellow(`No recent sandbox found, creating a new one.`),
+          theme.dim("--new flag detected, will create a new sandbox"),
         );
       }
     }
 
-    if (this.sandboxId) {
+    // order is important!
+    await this.connectToSandboxService();
+
+    const recentId = createNew ? null : this.getRecentSandboxId();
+
+    // Set up sandbox ID logic
+    if (createNew) {
+      // Skip any existing sandbox logic and go directly to new sandbox creation
+    } else if (recentId) {
+      this.emitter.emit(
+        events.log.log,
+        theme.dim(`- using recent sandbox: ${recentId}`),
+      );
+      this.sandboxId = recentId;
+    } else {
+      this.emitter.emit(
+        events.log.log,
+        theme.dim(`No recent sandbox found, creating a new one.`),
+      );
+    }
+
+    // Only attempt to connect to existing sandbox if not in CI mode and not creating new
+    if (this.sandboxId && !this.config.CI && !createNew) {
       // Attempt to connect to known instance
       this.emitter.emit(
         events.log.log,
@@ -1390,7 +1426,7 @@ ${regression}
       try {
         let instance = await this.connectToSandboxDirect(
           this.sandboxId,
-          options.persist,
+          true, // always persist by default
         );
 
         this.instance = instance;
@@ -1425,7 +1461,7 @@ ${regression}
     this.saveLastSandboxId(newSandbox.sandbox.instanceId);
     let instance = await this.connectToSandboxDirect(
       newSandbox.sandbox.instanceId,
-      options.persist,
+      true, // always persist by default
     );
     this.instance = instance;
     await this.renderSandbox(instance, headless);

--- a/agent/interface.js
+++ b/agent/interface.js
@@ -43,13 +43,9 @@ function createCommandDefinitions(agent) {
           description: "Run in headless mode (no GUI)",
           default: false,
         }),
-        persist: Flags.boolean({
-          description: "Prevent sandbox from being deleted after use",
-          default: false,
-        }),
-        reconnect: Flags.boolean({
+        new: Flags.boolean({
           description:
-            "Connect to the last sandbox instance (must have been created with --persist)",
+            "Create a new sandbox instead of reconnecting to an existing one",
           default: false,
         }),
         summary: Flags.string({
@@ -85,13 +81,9 @@ function createCommandDefinitions(agent) {
           description: "Run in headless mode",
           default: false,
         }),
-        persist: Flags.boolean({
-          description: "Prevent sandbox from being deleted after use",
-          default: false,
-        }),
-        reconnect: Flags.boolean({
+        new: Flags.boolean({
           description:
-            "Connect to the last sandbox instance (must have been created with --persist)",
+            "Create a new sandbox instead of reconnecting to an existing one",
           default: false,
         }),
         summary: Flags.string({

--- a/agent/lib/config.js
+++ b/agent/lib/config.js
@@ -42,6 +42,11 @@ const createConfig = (environment = {}) => {
     }
   }
 
+  // Add support for CI environment variable
+  if (environment.CI) {
+    config.CI = parseValue(environment.CI);
+  }
+
   return config;
 };
 

--- a/agent/lib/sandbox.js
+++ b/agent/lib/sandbox.js
@@ -17,20 +17,23 @@ const createSandbox = (emitter) => {
 
     send(message) {
       let resolvePromise;
+      let rejectPromise;
 
       if (this.socket) {
         this.messageId++;
         message.requestId = `${this.uniqueId}-${this.messageId}`;
 
-        let p = new Promise((resolve) => {
+        let p = new Promise((resolve, reject) => {
           this.socket.send(JSON.stringify(message));
           emitter.emit(events.sandbox.sent, message);
           resolvePromise = resolve;
+          rejectPromise = reject;
         });
 
         this.ps[message.requestId] = {
           promise: p,
           resolve: resolvePromise,
+          reject: rejectPromise,
           message,
         };
 


### PR DESCRIPTION
- `--persist` and `--reconnect` are the default behavior now, these commands are remoevd
- `--new` is used to force a new sandbox
- `--new` is set to `true` if `config.CI` (`process.env.ci`) is `true`