### PR TITLE
TDT-129 – Always run postrun, even on failure

### DIFF
--- a/agent/interface.js
+++ b/agent/interface.js
@@ -1,7 +1,5 @@
 const path = require("path");
 const { Args, Flags } = require("@oclif/core");
-const { events } = require("./events.js");
-const theme = require("./lib/theme.js");
 
 /**
  * Creates command definitions using oclif format as the single source of truth
@@ -61,22 +59,7 @@ function createCommandDefinitions(agent) {
         await agent.runLifecycle("prerun");
         // When run() is called through run.js CLI command, shouldExit should be true
         const shouldExit = agent.cliArgs?.command === "run";
-        try {
-          await agent.run(file, flags.write, shouldExit);
-        } catch (error) {
-          // If run() throws an error, we still need to run postrun
-          try {
-            await agent.runLifecycle("postrun");
-          } catch (postrunError) {
-            agent.emitter.emit(
-              events.log.warn,
-              theme.yellow(
-                `Warning: postrun lifecycle script failed: ${postrunError.message}`,
-              ),
-            );
-          }
-          throw error; // Re-throw the original error
-        }
+        await agent.run(file, flags.write, shouldExit);
       },
     },
 

--- a/agent/interface.js
+++ b/agent/interface.js
@@ -1,5 +1,7 @@
 const path = require("path");
 const { Args, Flags } = require("@oclif/core");
+const { events } = require("./events.js");
+const theme = require("./lib/theme.js");
 
 /**
  * Creates command definitions using oclif format as the single source of truth
@@ -59,7 +61,22 @@ function createCommandDefinitions(agent) {
         await agent.runLifecycle("prerun");
         // When run() is called through run.js CLI command, shouldExit should be true
         const shouldExit = agent.cliArgs?.command === "run";
-        await agent.run(file, flags.write, shouldExit);
+        try {
+          await agent.run(file, flags.write, shouldExit);
+        } catch (error) {
+          // If run() throws an error, we still need to run postrun
+          try {
+            await agent.runLifecycle("postrun");
+          } catch (postrunError) {
+            agent.emitter.emit(
+              events.log.warn,
+              theme.yellow(
+                `Warning: postrun lifecycle script failed: ${postrunError.message}`,
+              ),
+            );
+          }
+          throw error; // Re-throw the original error
+        }
       },
     },
 

--- a/interfaces/cli/lib/base.js
+++ b/interfaces/cli/lib/base.js
@@ -101,9 +101,14 @@ class BaseCommand extends Command {
     logger.createMarkdownLogger(this.agent.emitter);
 
     // Handle exit events
-    this.agent.emitter.on("error:fatal", (error) => {
+    this.agent.emitter.on("error:fatal", async (error) => {
       console.error("Fatal error:", error);
-      process.exit(1);
+      // Call the agent's exit method to ensure postrun lifecycle script is executed
+      if (this.agent) {
+        await this.agent.exit(true, false, true);
+      } else {
+        process.exit(1);
+      }
     });
 
     this.agent.emitter.on("exit", (exitCode) => {

--- a/testdriver/behavior/lifecycle/postrun.yaml
+++ b/testdriver/behavior/lifecycle/postrun.yaml
@@ -1,0 +1,8 @@
+version: 6.0.1-canary.4f31816.0
+session: 68767e31eb9cc3d8f639b8e0
+steps:
+  - prompt: "run"
+    commands:
+      - command: exec
+        lang: pwsh
+        code: Write-Output "postrun.yaml"

--- a/testdriver/behavior/lifecycle/prerun.yaml
+++ b/testdriver/behavior/lifecycle/prerun.yaml
@@ -1,0 +1,8 @@
+version: 6.0.1-canary.4f31816.0
+session: 68767e31eb9cc3d8f639b8e0
+steps:
+  - prompt: "run"
+    commands:
+      - command: exec
+        lang: pwsh
+        code: Write-Output "prerun.yaml"

--- a/testdriver/behavior/lifecycle/provision.yaml
+++ b/testdriver/behavior/lifecycle/provision.yaml
@@ -1,0 +1,8 @@
+version: 6.0.1-canary.4f31816.0
+session: 68767e31eb9cc3d8f639b8e0
+steps:
+  - prompt: "run"
+    commands:
+      - command: exec
+        lang: pwsh
+        code: Write-Output "provision.yaml"


### PR DESCRIPTION
https://www.notion.so/postrun-lifecycle-script-doesn-t-run-test-failure-23a6adb97c888026a58bc62804a1bc1b?v=1f46adb97c88807ca025000c05b7b897&source=copy_link

I spent a while doing this by hand, but there were so many places that `runLifeCycle` was called (or an `await ...` wasn't being caught) that I had Cursor just wrap everything until we found the right place in code [a6b4110](https://github.com/testdriverai/cli/pull/368/commits/a6b41100e781c911abe95cd373c8affda8f0941c) and then removed the noise [f7af058](https://github.com/testdriverai/cli/pull/368/commits/f7af058c3d1348039ab2949b6b142b61ab0df2c6).

As you can see in the demos, `prerun.yaml` executes, **but wasn't running `postrun.yaml`**.

With this change, it always runs with `run`, but _not_ with `edit`.

## Demo

### Before

```console
$ npm run dev run testdriver/behavior/failure.yaml --reconnect --persist

npm warn Unknown cli config "--reconnect". This will stop working in the next major version of npm.
npm warn Unknown cli config "--persist". This will stop working in the next major version of npm.

> testdriverai@6.0.10 dev
> DEV=true node bin/testdriverai.js run testdriver/behavior/failure.yaml

Log file created at: /var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/testdriverai-cli-67706.log
Howdy! I'm TestDriver v6.0.10
Starting debugger server...
This is beta software!
Join our Forums for help
https://forums.testdriver.ai
Working on /Users/eric/Projects/testdriverai/cli/testdriver/behavior/failure.yaml
- establishing connection...
- authenticating...
- using recent sandbox: i-09c7883b59373a262
- connecting to sandbox i-09c7883b59373a262...
- connecting...
Live test execution: 
http://localhost:62695?data=%7B%22resolution%22%3A%5B1366%2C768%5D%2C%22url%22%3A%22http%3A%2F%2F3.143.229.61%3A8080%2Fvnc_lite.html%22%2C%22token%22%3A%22V3b8wG9%22%7D
running /Users/eric/Projects/testdriverai/cli/testdriver/behavior/lifecycle/prerun.yaml...

> run
prerun.yaml:4:6 (exec)
command='exec' code='Write-Output "prerun.yaml"' lang='pwsh'
calling exec...
Write-Output "prerun.yaml"
Command stdout:
prerun.yaml

running /Users/eric/Projects/testdriverai/cli/testdriver/behavior/failure.yaml...

> close chrome
failure.yaml:4:6 (assert)
command='assert' expect='a pink elephant appears on screen'
thinking...
    The task failed. There is no pink elephant visible on the
    screen.
    
error:general : Error detected, but recovery mode is not enabled.
To attempt automatic recovery, re-run with the --heal flag.
Fatal error: Error in failure.yaml:

   3     steps:
   4       - prompt: close chrome
   5         commands:
   6 >>>       - command: assert
   7             expect: a pink elephant appears on screen
   8     

Error: AI Assertion failed
```

### After

```console
node bin/testdriverai.js run testdriver/behavior/failure.yaml                           node bin/testdriverai.js run testdriver/behavior/failure.yaml
Log file created at: /var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/testdriverai-cli-71112.log
Howdy! I'm TestDriver v6.0.10
Starting debugger server...
This is beta software!
Join our Forums for help
https://forums.testdriver.ai
Working on /Users/eric/Projects/testdriverai/cli/testdriver/behavior/failure.yaml
- establishing connection...
- authenticating...
- using recent sandbox: i-03f9bdf057bf882ae
- connecting to sandbox i-03f9bdf057bf882ae...
- connecting...
Live test execution: 
http://localhost:63227?data=%7B%22resolution%22%3A%5B1366%2C768%5D%2C%22url%22%3A%22http%3A%2F%2F3.17.167.244%3A8080%2Fvnc_lite.html%22%2C%22token%22%3A%22V3b8wG9%22%7D
running /Users/eric/Projects/testdriverai/cli/testdriver/behavior/lifecycle/prerun.yaml...

> run
prerun.yaml:4:6 (exec)
command='exec' code='Write-Output "prerun.yaml"' lang='pwsh'
calling exec...
Write-Output "prerun.yaml"
Command stdout:
prerun.yaml

running /Users/eric/Projects/testdriverai/cli/testdriver/behavior/failure.yaml...

> close chrome
failure.yaml:4:6 (assert)
command='assert' expect='a pink elephant appears on screen'
thinking...
    The task failed: there is no pink elephant visible on the
    desktop.
    
error:general : Error detected, but recovery mode is not enabled.
To attempt automatic recovery, re-run with the --heal flag.
Fatal error: Error in failure.yaml:

   3     steps:
   4       - prompt: close chrome
   5         commands:
   6 >>>       - command: assert
   7             expect: a pink elephant appears on screen
   8     

Error: AI Assertion failed
exiting...
running /Users/eric/Projects/testdriverai/cli/testdriver/behavior/lifecycle/postrun.yaml...
error:fatal : Error in failure.yaml:

   3     steps:
   4       - prompt: close chrome
   5         commands:
   6 >>>       - command: assert
   7             expect: a pink elephant appears on screen
   8     

Error: AI Assertion failed
reviewing test...

> run
postrun.yaml:4:6 (exec)
command='exec' code='Write-Output "postrun.yaml"' lang='pwsh'
calling exec...
Write-Output "postrun.yaml"
Command stdout:
postrun.yaml
```

```console
npm run dev edit testdriver/behavior/failure.yaml --reconnect --persist
npm warn Unknown cli config "--reconnect". This will stop working in the next major version of npm.
npm warn Unknown cli config "--persist". This will stop working in the next major version of npm.

> testdriverai@6.0.10 dev
> DEV=true node bin/testdriverai.js edit testdriver/behavior/failure.yaml

Log file created at: /var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/testdriverai-cli-71367.log
Howdy! I'm TestDriver v6.0.10
Starting debugger server...
This is beta software!
Join our Forums for help
https://forums.testdriver.ai
Working on /Users/eric/Projects/testdriverai/cli/testdriver/behavior/failure.yaml
- establishing connection...
- authenticating...
- using recent sandbox: i-03f9bdf057bf882ae
- connecting to sandbox i-03f9bdf057bf882ae...
- connecting...
Live test execution: 
http://localhost:63271?data=%7B%22resolution%22%3A%5B1366%2C768%5D%2C%22url%22%3A%22http%3A%2F%2F3.17.167.244%3A8080%2Fvnc_lite.html%22%2C%22token%22%3A%22V3b8wG9%22%7D
Loaded test script /Users/eric/Projects/testdriverai/cli/testdriver/behavior/failure.yaml

      version: 6.0.1-canary.4f31816.0
      session: 68767e31eb9cc3d8f639b8e0
      steps:
        - prompt: close chrome
          commands:
            - command: assert
              expect: a pink elephant appears on screen
    
New commands will be appended.
> exiting...
```