### PR TITLE
Screenshot Debugger

### DIFF
--- a/agent/events.js
+++ b/agent/events.js
@@ -39,6 +39,10 @@ const events = {
     end: "screen-capture:end",
     error: "screen-capture:error",
   },
+  screenshot: {
+    error: "screenshot:error",
+    success: "screenshot:success",
+  },
   terminal: {
     stdout: "terminal:stdout",
     stderr: "terminal:stderr",

--- a/agent/lib/debugger-server.js
+++ b/agent/lib/debugger-server.js
@@ -2,7 +2,7 @@ const WebSocket = require("ws");
 const http = require("http");
 const path = require("path");
 const fs = require("fs");
-const { eventsArray, getEmitter } = require("../events.js");
+const { eventsArray } = require("../events.js");
 
 let server = null;
 let wss = null;
@@ -105,18 +105,18 @@ function broadcastEvent(event, data) {
   });
 }
 
-async function startDebugger(config = {}) {
+async function startDebugger(config = {}, emitter) {
   try {
     const { port } = await createDebuggerServer(config);
     const url = `http://localhost:${port}`;
 
     // Set up event listeners for all events
-    const emitter = getEmitter();
-
-    for (const event of eventsArray) {
-      emitter.on(event, async (data) => {
-        broadcastEvent(event, data);
-      });
+    if (emitter) {
+      for (const event of eventsArray) {
+        emitter.on(event, async (data) => {
+          broadcastEvent(event, data);
+        });
+      }
     }
 
     return { port, url };

--- a/agent/lib/debugger.js
+++ b/agent/lib/debugger.js
@@ -1,9 +1,9 @@
-const { eventsArray, getEmitter } = require("../events.js");
+const { eventsArray } = require("../events.js");
 const { startDebugger, broadcastEvent } = require("./debugger-server.js");
 
-module.exports.createDebuggerProcess = (config = {}) => {
+module.exports.createDebuggerProcess = (config = {}, emitter) => {
   // Start the web server-based debugger instead of Electron
-  return startDebugger(config)
+  return startDebugger(config, emitter)
     .then(({ url }) => {
       // Return a mock process object to maintain compatibility
       return {
@@ -26,11 +26,10 @@ module.exports.createDebuggerProcess = (config = {}) => {
     });
 };
 
-module.exports.connectToDebugger = () => {
+module.exports.connectToDebugger = (emitter) => {
   return new Promise((resolve, reject) => {
     // Set up event broadcasting instead of IPC
     try {
-      const emitter = getEmitter();
       eventsArray.forEach((event) => {
         emitter.on(event, (data) => {
           broadcastEvent(event, data);

--- a/agent/lib/system.js
+++ b/agent/lib/system.js
@@ -15,14 +15,16 @@ const createSystem = (sandbox, config, emitter) => {
         let { base64 } = await sandbox.send({ type: "system.screenshot" });
 
         if (!base64) {
-          const error = new Error(`Failed to take screenshot - no base64 data received (attempt ${attempt}/${maxRetries})`);
+          const error = new Error(
+            `Failed to take screenshot - no base64 data received (attempt ${attempt}/${maxRetries})`,
+          );
           lastError = error;
-          
+
           emitter.emit(events.screenshot.error, {
             error,
             attempt,
             maxRetries,
-            options
+            options,
           });
 
           if (attempt === maxRetries) {
@@ -33,25 +35,25 @@ const createSystem = (sandbox, config, emitter) => {
 
         let image = Buffer.from(base64, "base64");
         fs.writeFileSync(options.filename, image);
-        
+
         if (attempt > 1) {
           emitter.emit(events.screenshot.success, {
             attempt,
             maxRetries,
             options,
-            filename: options.filename
+            filename: options.filename,
           });
         }
-        
+
         return { filename: options.filename };
       } catch (error) {
         lastError = error;
-        
+
         emitter.emit(events.screenshot.error, {
           error,
           attempt,
           maxRetries,
-          options
+          options,
         });
 
         if (attempt === maxRetries) {

--- a/interfaces/cli/lib/base.js
+++ b/interfaces/cli/lib/base.js
@@ -74,6 +74,11 @@ class BaseCommand extends Command {
       console.error(event, ":", data);
     });
 
+    // Use pattern matching for error events
+    this.agent.emitter.on("screenshot:error", (data) => {
+      console.log("Screenshot error:", data.error);
+    });
+
     // Handle status events
     this.agent.emitter.on("status", (message) => {
       console.log(`- ${message}`);


### PR DESCRIPTION
Failing screenshots is something I saw in dev, but might have been obstructed with a refactor. This could be the cause for silent timeouts in prod. This adds a retry for screenshots, and logs when they fail.