### PR TITLE
Ianjennings/screenshot debug

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -105,8 +105,8 @@ class TestDriverAgent extends EventEmitter2 {
     // Create sandbox instance with this agent's emitter
     this.sandbox = createSandbox(this.emitter);
 
-    // Create system instance with sandbox and config
-    this.system = createSystem(this.sandbox, this.config);
+    // Create system instance with sandbox, config, and emitter
+    this.system = createSystem(this.sandbox, this.config, this.emitter);
 
     // Create commands instance with this agent's emitter and system
     const commandsResult = createCommands(

--- a/agent/lib/debugger-server.js
+++ b/agent/lib/debugger-server.js
@@ -2,7 +2,7 @@ const WebSocket = require("ws");
 const http = require("http");
 const path = require("path");
 const fs = require("fs");
-const { eventsArray, getEmitter } = require("../events.js");
+const { eventsArray } = require("../events.js");
 
 let server = null;
 let wss = null;
@@ -105,14 +105,12 @@ function broadcastEvent(event, data) {
   });
 }
 
-async function startDebugger(config = {}) {
+async function startDebugger(config = {}, emitter) {
   try {
     const { port } = await createDebuggerServer(config);
     const url = `http://localhost:${port}`;
 
     // Set up event listeners for all events
-    const emitter = getEmitter();
-
     for (const event of eventsArray) {
       emitter.on(event, async (data) => {
         broadcastEvent(event, data);

--- a/agent/lib/debugger.js
+++ b/agent/lib/debugger.js
@@ -1,9 +1,9 @@
-const { eventsArray, getEmitter } = require("../events.js");
+const { eventsArray } = require("../events.js");
 const { startDebugger, broadcastEvent } = require("./debugger-server.js");
 
-module.exports.createDebuggerProcess = (config = {}) => {
+module.exports.createDebuggerProcess = (config = {}, emitter) => {
   // Start the web server-based debugger instead of Electron
-  return startDebugger(config)
+  return startDebugger(config, emitter)
     .then(({ url }) => {
       // Return a mock process object to maintain compatibility
       return {
@@ -26,11 +26,10 @@ module.exports.createDebuggerProcess = (config = {}) => {
     });
 };
 
-module.exports.connectToDebugger = () => {
+module.exports.connectToDebugger = (emitter) => {
   return new Promise((resolve, reject) => {
     // Set up event broadcasting instead of IPC
     try {
-      const emitter = getEmitter();
       eventsArray.forEach((event) => {
         emitter.on(event, (data) => {
           broadcastEvent(event, data);


### PR DESCRIPTION
Failing screenshots is something I saw in dev, but might have been obstructed with a refactor. This could be the cause for silent timeouts in prod. This adds a retry for screenshots, and logs when they fail.