### PR TITLE
single emitter per instance

### DIFF
--- a/agent/events.js
+++ b/agent/events.js
@@ -1,8 +1,5 @@
 const { EventEmitter2 } = require("eventemitter2");
 
-// Global reference to the current agent's emitter
-let currentEmitter = null;
-
 // Factory function to create a new emitter instance
 const createEmitter = () => {
   const emitter = new EventEmitter2({
@@ -15,19 +12,6 @@ const createEmitter = () => {
     ignoreErrors: false,
   });
   return emitter;
-};
-
-// Function to set the current emitter for all modules to use
-const setEmitter = (emitter) => {
-  currentEmitter = emitter;
-};
-
-// Function to get the current emitter
-const getEmitter = () => {
-  if (!currentEmitter) {
-    throw new Error("Emitter not initialized. Call setEmitter() first.");
-  }
-  return currentEmitter;
 };
 
 const events = {
@@ -131,4 +115,4 @@ const getValues = (obj) => {
 
 const eventsArray = getValues(events);
 
-module.exports = { events, createEmitter, setEmitter, getEmitter, eventsArray };
+module.exports = { events, createEmitter, eventsArray };

--- a/agent/index.js
+++ b/agent/index.js
@@ -35,7 +35,7 @@ const { createSession } = require("./lib/session.js");
 const { createOutputs } = require("./lib/outputs.js");
 
 const isValidVersion = require("./lib/valid-version.js");
-const { events, createEmitter, setEmitter } = require("./events.js");
+const { events, createEmitter } = require("./events.js");
 const { createDebuggerProcess } = require("./lib/debugger.js");
 let debuggerProcess = null; // single debugger process for all instances. otherwise they'll fight over ports. this should be in `web` anyway
 let debuggerStarted = false;
@@ -84,9 +84,6 @@ class TestDriverAgent extends EventEmitter2 {
       }
     }
 
-    // Set this emitter as the global current emitter for other modules to use
-    setEmitter(this.emitter);
-
     // Create parser instance with this agent's emitter
     this.parser = createParser(this.emitter);
 
@@ -105,8 +102,8 @@ class TestDriverAgent extends EventEmitter2 {
     // Create sandbox instance with this agent's emitter
     this.sandbox = createSandbox(this.emitter);
 
-    // Create system instance with sandbox and config
-    this.system = createSystem(this.sandbox, this.config);
+    // Create system instance with emitter, sandbox and config
+    this.system = createSystem(this.emitter, this.sandbox, this.config);
 
     // Create commands instance with this agent's emitter and system
     const commandsResult = createCommands(

--- a/agent/lib/debugger-server.js
+++ b/agent/lib/debugger-server.js
@@ -2,7 +2,7 @@ const WebSocket = require("ws");
 const http = require("http");
 const path = require("path");
 const fs = require("fs");
-const { eventsArray, getEmitter } = require("../events.js");
+const { eventsArray } = require("../events.js");
 
 let server = null;
 let wss = null;
@@ -105,14 +105,12 @@ function broadcastEvent(event, data) {
   });
 }
 
-async function startDebugger(config = {}) {
+async function startDebugger(config = {}, emitter) {
   try {
     const { port } = await createDebuggerServer(config);
     const url = `http://localhost:${port}`;
 
     // Set up event listeners for all events
-    const emitter = getEmitter();
-
     for (const event of eventsArray) {
       emitter.on(event, async (data) => {
         broadcastEvent(event, data);

--- a/agent/lib/debugger.js
+++ b/agent/lib/debugger.js
@@ -1,9 +1,9 @@
-const { eventsArray, getEmitter } = require("../events.js");
+const { eventsArray } = require("../events.js");
 const { startDebugger, broadcastEvent } = require("./debugger-server.js");
 
-module.exports.createDebuggerProcess = (config = {}) => {
+module.exports.createDebuggerProcess = (config = {}, emitter) => {
   // Start the web server-based debugger instead of Electron
-  return startDebugger(config)
+  return startDebugger(config, emitter)
     .then(({ url }) => {
       // Return a mock process object to maintain compatibility
       return {
@@ -26,11 +26,10 @@ module.exports.createDebuggerProcess = (config = {}) => {
     });
 };
 
-module.exports.connectToDebugger = () => {
+module.exports.connectToDebugger = (emitter) => {
   return new Promise((resolve, reject) => {
     // Set up event broadcasting instead of IPC
     try {
-      const emitter = getEmitter();
       eventsArray.forEach((event) => {
         emitter.on(event, (data) => {
           broadcastEvent(event, data);

--- a/agent/lib/system.js
+++ b/agent/lib/system.js
@@ -3,9 +3,9 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const Jimp = require("jimp");
-const { getEmitter, events } = require("../events.js");
+const { events } = require("../events.js");
 
-const createSystem = (sandbox, config) => {
+const createSystem = (emitter, sandbox, config) => {
   const screenshot = async (options) => {
     let { base64 } = await sandbox.send({ type: "system.screenshot" });
 
@@ -35,7 +35,7 @@ const createSystem = (sandbox, config) => {
   const captureAndResize = async (scale = 1, silent = false, mouse = false) => {
     try {
       if (!silent) {
-        getEmitter().emit(events.screenCapture.start, {
+        emitter.emit(events.screenCapture.start, {
           scale,
           silent,
           display: primaryDisplay,
@@ -70,7 +70,7 @@ const createSystem = (sandbox, config) => {
 
       await image.writeAsync(step2);
 
-      getEmitter().emit(events.screenCapture.end, {
+      emitter.emit(events.screenCapture.end, {
         scale,
         silent,
         display: primaryDisplay,
@@ -78,7 +78,7 @@ const createSystem = (sandbox, config) => {
 
       return step2;
     } catch (error) {
-      getEmitter().emit(events.screenCapture.error, {
+      emitter.emit(events.screenCapture.error, {
         error,
         scale,
         silent,

--- a/testdriver/acceptance/assert.yaml
+++ b/testdriver/acceptance/assert.yaml
@@ -1,7 +1,7 @@
 version: 6.0.1
 session: 6877c33b74c5eac738259a74
 steps:
-  - prompt: asserogt the testdriver login page shows
+  - prompt: assert the testdriver login page shows
     commands:
       - command: assert
         expect: the TestDriver.ai Sandbox login page is displayed


### PR DESCRIPTION
This fixes issues when running multiple instances within the same process. We don't want those instances to share emitters.