### PR TITLE
TDT-124 – Document `max-parallels` (and limit our CI usage)

### DIFF
--- a/.github/workflows/acceptance-v6.yml
+++ b/.github/workflows/acceptance-v6.yml
@@ -37,7 +37,9 @@ jobs:
     strategy:
       matrix:
         test: ${{ fromJson(needs.gather-test-files.outputs.test_files) }}
+      max-parallel: 8
       fail-fast: false
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/features/parallel-testing.mdx
+++ b/docs/features/parallel-testing.mdx
@@ -15,6 +15,7 @@ Parallel testing allows you to run multiple tests simultaneously, significantly 
 2. **Scalability**: Easily scale your testing efforts as your test suite grows.
 3. **Dynamic Distribution**: Automatically distribute tests across jobs using GitHub's matrix strategy.
 4. **Cost Efficiency**: Optimize resource usage by running tests in parallel.
+5. **Reliability**: Avoid failures from going beyond your [plan's max instances](https://testdriver.ai/pricing).
 
 ---
 
@@ -66,6 +67,8 @@ jobs:
       matrix:
         test: ${{ fromJson(needs.gather-test-files.outputs.test_files) }}
       fail-fast: false
+      max-parallel: 8
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -98,30 +101,31 @@ jobs:
 
 1. **`gather-test-files` Job**:
 
-- Collects all test files in the `testdriver/acceptance/` directory.
-- Uses `basename` to get just the filenames without the full path.
-- Outputs the list of test files as a JSON array for the matrix strategy.
+   - Collects all test files in the `testdriver/acceptance/` directory.
+   - Uses `basename` to get just the filenames without the full path.
+   - Outputs the list of test files as a JSON array for the matrix strategy.
 
 2. **`run-tests` Job**:
 
-- Uses the matrix strategy to dynamically create a job for each test file.
-- Sets up Node.js and installs dependencies for TestDriver CLI.
-- Runs each test file in parallel using `npx testdriverai@latest` with the `--headless` flag.
+   - Uses the matrix strategy to dynamically create a job for each test file.
+   - Sets up Node.js and installs dependencies for TestDriver CLI.
+   - Runs each test file in parallel using `npx testdriverai@latest` with the `--headless` flag.
+   - The `max-parallel` setting limits the number of tests that can run in parallel to `8` (the max instances for the [Medium Team Plan](https://testdriver.ai/pricing)).
 
 3. **Matrix Strategy**:
 
-- The `matrix.test` variable represents each test filename.
-- Each job runs a single test file from the `testdriver/acceptance/` directory.
+   - The `matrix.test` variable represents each test filename.
+   - Each job runs a single test file from the `testdriver/acceptance/` directory.
 
 4. **Environment Variables**:
 
-- `TD_API_KEY`: Your TestDriver API key for authentication.
-- `TD_WEBSITE`: The target website URL for testing.
-- `TD_THIS_FILE`: The current test file being executed.
+   - `TD_API_KEY`: Your TestDriver API key for authentication.
+   - `TD_WEBSITE`: The target website URL for testing.
+   - `TD_THIS_FILE`: The current test file being executed.
 
 5. **Fail-Fast**:
 
-- Set to `false` to ensure all tests run even if one fails.
+   - Set to `false` to ensure all tests run even if one fails.
 
 ---
 


### PR DESCRIPTION
- Limited acceptance tests to 8 to avoid hitting API "Max instances" limits.
- Added documentation for the max-parallel setting to control concurrency in GitHub Actions workflows.

https://www.notion.so/Document-Concurrency-2386adb97c888033bcabdd4e9169864c?source=copy_link
<img width="599" height="1038" alt="Screenshot 2025-07-28 at 12 22 16 PM" src="https://github.com/user-attachments/assets/2e859a38-0de1-4516-8c29-c6a1d78981aa" />
<img width="1437" height="841" alt="Screenshot 2025-07-28 at 12 22 33 PM" src="https://github.com/user-attachments/assets/0258c677-4384-4a8d-b82d-bb87e1dfb98d" />

