### PR TITLE
dont scope sub functions

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -117,6 +117,7 @@ class TestDriverAgent extends EventEmitter2 {
       () => this.sourceMapper.currentFilePath || this.thisFile,
     );
     this.commands = commandsResult.commands;
+    this.redraw = commandsResult.redraw;
 
     // Create commander instance with this agent's emitter and commands
     this.commander = createCommander(
@@ -157,6 +158,11 @@ class TestDriverAgent extends EventEmitter2 {
   // allows us to save the current state, run lifecycle hooks, and track analytics
   async exit(failed = true, shouldSave = false, shouldRunLifecycle = false) {
     this.emitter.emit(events.log.log, theme.dim("exiting..."), true);
+
+    // Clean up redraw interval
+    if (this.redraw && this.redraw.cleanup) {
+      this.redraw.cleanup();
+    }
 
     shouldRunLifecycle = shouldRunLifecycle || this.cliArgs?.command == "run";
 

--- a/agent/lib/commands.js
+++ b/agent/lib/commands.js
@@ -798,8 +798,8 @@ const createCommands = (
     },
   };
 
-  // Return the commands and assert function
-  return { commands, assert };
+  // Return the commands, assert function, and redraw instance
+  return { commands, assert, redraw };
 };
 
 // Export the factory function

--- a/agent/lib/redraw.js
+++ b/agent/lib/redraw.js
@@ -19,13 +19,13 @@ const createRedraw = (emitter, system, sandbox) => {
   let networkSettled = true;
   let screenHasRedrawn = null;
 
-  async function resetState() {
+  const resetState = async () => {
     lastTxBytes = null;
     lastRxBytes = null;
     measurements = [];
     networkSettled = true;
     screenHasRedrawn = false;
-  }
+  };
 
   const parseNetworkStats = (thisRxBytes, thisTxBytes) => {
     diffRxBytes = lastRxBytes !== null ? thisRxBytes - lastRxBytes : 0;
@@ -64,7 +64,7 @@ const createRedraw = (emitter, system, sandbox) => {
     }
   };
 
-  async function updateNetwork() {
+  const updateNetwork = async () => {
     if (sandbox && sandbox.instanceSocketConnected) {
       let network = await sandbox.send({
         type: "system.network",
@@ -74,9 +74,9 @@ const createRedraw = (emitter, system, sandbox) => {
         network.out.totalBytesSent,
       );
     }
-  }
+  };
 
-  async function imageDiffPercent(image1Url, image2Url) {
+  const imageDiffPercent = async (image1Url, image2Url) => {
     // generate a temporary file path
     const tmpImage = path.join(os.tmpdir(), `tmp-${Date.now()}.png`);
 
@@ -99,17 +99,17 @@ const createRedraw = (emitter, system, sandbox) => {
         return false;
       }
     }
-  }
+  };
 
   let startImage = null;
 
-  async function start() {
+  const start = async () => {
     resetState();
     startImage = await system.captureScreenPNG(0.25, true);
     return startImage;
-  }
+  };
 
-  async function checkCondition(resolve, startTime, timeoutMs) {
+  const checkCondition = async (resolve, startTime, timeoutMs) => {
     let nowImage = await system.captureScreenPNG(0.25, true);
     let timeElapsed = Date.now() - startTime;
     let diffPercent = 0;
@@ -167,14 +167,14 @@ const createRedraw = (emitter, system, sandbox) => {
         checkCondition(resolve, startTime, timeoutMs);
       }, 500);
     }
-  }
+  };
 
-  function wait(timeoutMs) {
+  const wait = (timeoutMs) => {
     return new Promise((resolve) => {
       const startTime = Date.now();
       checkCondition(resolve, startTime, timeoutMs);
     });
-  }
+  };
 
   setInterval(updateNetwork, networkUpdateInterval);
 


### PR DESCRIPTION
It seems like `redraw` might be spawaning new intervals for every command, at least within VS Code. I can see in datadog that a single machine is sending 3 network commands per second, yet the interval is `15000ms`. 

<img width="1938" height="1616" alt="CleanShot 2025-07-30 at 22 36 03@2x" src="https://github.com/user-attachments/assets/33f3d463-0ff5-456d-b084-21d76565bf5c" />
