### PR TITLE
rm unwanted logging

### DIFF
--- a/agent/lib/redraw.js
+++ b/agent/lib/redraw.js
@@ -65,9 +65,6 @@ const createRedraw = (emitter, system, sandbox) => {
   };
 
   async function updateNetwork() {
-    if (process.env.VERBOSE === "true") {
-      console.debug("Updating network stats...");
-    }
     if (sandbox && sandbox.instanceSocketConnected) {
       let network = await sandbox.send({
         type: "system.network",

--- a/agent/lib/redraw.js
+++ b/agent/lib/redraw.js
@@ -65,7 +65,9 @@ const createRedraw = (emitter, system, sandbox) => {
   };
 
   async function updateNetwork() {
-    console.debug("Updating network stats...");
+    if (process.env.VERBOSE === "true") {
+      console.debug("Updating network stats...");
+    }
     if (sandbox && sandbox.instanceSocketConnected) {
       let network = await sandbox.send({
         type: "system.network",


### PR DESCRIPTION
Printing unnecessary log in the prod l[ike this](https://github.com/testdriverai/pieces/actions/runs/16676428898/job/47204056398#step:3:27)

so after the PR it only gets logged while doing `npm run dev` 

_PS: stopping the acceptance tests for this, to save time and resources 🤌_