### PR TITLE
dont generate unique id for logs

### DIFF
--- a/agent/lib/sandbox.js
+++ b/agent/lib/sandbox.js
@@ -25,7 +25,7 @@ const createSandbox = (emitter, analytics) => {
         message.requestId = `${this.uniqueId}-${this.messageId}`;
 
         // Start timing for this message
-        const timingKey = `sandbox-${message.type}-${message.requestId}`;
+        const timingKey = `sandbox-${message.type}`;
         marky.mark(timingKey);
 
         let p = new Promise((resolve, reject) => {


### PR DESCRIPTION
The unique IDs make our performance metrics impossible to digest

<img width="993" height="479" alt="CleanShot 2025-08-06 at 12 48 16" src="https://github.com/user-attachments/assets/7bc73cff-3c28-41d6-9770-ba3de84295b8" />
