### PR TITLE
Prevent postrun from infinite loop

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -201,7 +201,8 @@ class TestDriverAgent extends EventEmitter2 {
     }
 
     await this.summarize(error.message);
-    return await this.exit(true);
+    // Always run postrun lifecycle script, even for fatal errors
+    return await this.exit(true, false, true);
   }
 
   // creates a new "thread" in which the AI is given an error

--- a/interfaces/cli/lib/base.js
+++ b/interfaces/cli/lib/base.js
@@ -1,3 +1,10 @@
+/*
+This is an implementation of the TestDriver library. This file should not:
+- modify the agent's state
+- emit events back to the agent
+- etc
+*/
+
 const { Command } = require("@oclif/core");
 const { events } = require("../../../agent/events.js");
 const { createCommandDefinitions } = require("../../../agent/interface.js");
@@ -99,17 +106,6 @@ class BaseCommand extends Command {
     });
 
     logger.createMarkdownLogger(this.agent.emitter);
-
-    // Handle exit events
-    this.agent.emitter.on("error:fatal", async (error) => {
-      console.error("Fatal error:", error);
-      // Call the agent's exit method to ensure postrun lifecycle script is executed
-      if (this.agent) {
-        await this.agent.exit(true, false, true);
-      } else {
-        process.exit(1);
-      }
-    });
 
     this.agent.emitter.on("exit", (exitCode) => {
       process.exit(exitCode);

--- a/interfaces/cli/lib/base.js
+++ b/interfaces/cli/lib/base.js
@@ -101,9 +101,14 @@ class BaseCommand extends Command {
     logger.createMarkdownLogger(this.agent.emitter);
 
     // Handle exit events
-    this.agent.emitter.on("error:fatal", (error) => {
+    this.agent.emitter.on("error:fatal", async (error) => {
       console.error("Fatal error:", error);
-      process.exit(1);
+      // Call the agent's exit method to ensure postrun lifecycle script is executed
+      if (this.agent) {
+        await this.agent.exit(true, false, true);
+      } else {
+        process.exit(1);
+      }
     });
 
     this.agent.emitter.on("exit", (exitCode) => {

--- a/testdriver/behavior/lifecycle/postrun.yaml
+++ b/testdriver/behavior/lifecycle/postrun.yaml
@@ -1,0 +1,8 @@
+version: 6.0.1-canary.4f31816.0
+session: 68767e31eb9cc3d8f639b8e0
+steps:
+  - prompt: "run"
+    commands:
+      - command: exec
+        lang: pwsh
+        code: Write-Output "postrun.yaml"

--- a/testdriver/behavior/lifecycle/postrun.yaml
+++ b/testdriver/behavior/lifecycle/postrun.yaml
@@ -5,4 +5,6 @@ steps:
     commands:
       - command: exec
         lang: pwsh
-        code: Write-Output "postrun.yaml"
+        code: |
+          Write-Output "postrun.yaml"
+          exit 1

--- a/testdriver/behavior/lifecycle/prerun.yaml
+++ b/testdriver/behavior/lifecycle/prerun.yaml
@@ -1,0 +1,8 @@
+version: 6.0.1-canary.4f31816.0
+session: 68767e31eb9cc3d8f639b8e0
+steps:
+  - prompt: "run"
+    commands:
+      - command: exec
+        lang: pwsh
+        code: Write-Output "prerun.yaml"

--- a/testdriver/behavior/lifecycle/provision.yaml
+++ b/testdriver/behavior/lifecycle/provision.yaml
@@ -1,0 +1,8 @@
+version: 6.0.1-canary.4f31816.0
+session: 68767e31eb9cc3d8f639b8e0
+steps:
+  - prompt: "run"
+    commands:
+      - command: exec
+        lang: pwsh
+        code: Write-Output "provision.yaml"


### PR DESCRIPTION
This logic prevents postrun from running in a loop if it encounters an error. It can be tested with:

```
node bin/testdriverai.js run testdriver/behavior/failure.yaml
```