### PR TITLE
TDT-153-timeout-github-actions

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -32,6 +32,7 @@ jobs:
     needs:
       - gather-test-files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       matrix:


### PR DESCRIPTION
Timeout individual acceptance tests to 10 minutes