### PR TITLE
add test for scroll-until-image [skip ci]

### DIFF
--- a/testdriver/acceptance/scroll-until-image.yaml
+++ b/testdriver/acceptance/scroll-until-image.yaml
@@ -1,0 +1,21 @@
+version: 6.0.0
+session: 67f00511acbd9ccac373edf7
+steps:
+  - prompt: scroll until image
+    commands:
+      - command: press-keys
+        keys: 
+          - ctrl
+          - l
+      - command: type
+        text: https://en.wikipedia.org/wiki/Leonardo_da_Vinci
+      - command: press-keys
+        keys: 
+          - enter
+      - command: hover-text
+        text: Leonardo Da Vinci
+        description: the page heazding
+        action: click
+      - command: scroll-until-image
+        description: a brown colored house
+        direction: down


### PR DESCRIPTION
Couple of things: 
- 
1. I am considering [Leonardo Da Vinci's wikipedia page](https://en.wikipedia.org/wiki/Leonardo_da_Vinci) to test on. 
Now I am unsure if its the right page or something, again this got spun off when I was fixing the docs and saw there was no rec iframe for the [scroll-until-image page](https://docs.testdriver.ai/commands/scroll-until-image#scroll-until-image) so I couldn't invest much time for this. And one of my favorite sayings is :

> _There's nothing more permanent than a temporary solution that works_ 

2. The `scroll-until-image page` works by referencing either the `description` or a `path` to the reference image, 
**this test doesn't test the latter**.  Mainly because underneath the hood its just using [match-image](https://github.com/testdriverai/cli/blob/eaf2ed9a872935bb77e39358c2d97ba5f94db685/agent/lib/commands.js#L661) and we do have a separate test for that, so I am kinda thinking its a liability than an asset.
---

Anyways, here's the dashcam link for this test passing (ran locally) - https://app.dashcam.io/replay/68a09bc81de6c897786fa4a8?share=6w2iJujGcHicteavbBIEQ
