### PR TITLE
Make scroll-until-text parity with scroll-until-image

### DIFF
--- a/agent/lib/commands.js
+++ b/agent/lib/commands.js
@@ -574,10 +574,7 @@ const createCommands = (
       }
 
       let scrollDistance = 0;
-      let incrementDistance = 300;
-      if (method === "mouse") {
-        incrementDistance = 200;
-      }
+      let incrementDistance = 500;
       let passed = false;
 
       while (scrollDistance <= maxDistance && !passed) {


### PR DESCRIPTION
This is the minimal change needed to make it in parity. 
I wrote some of the original code for this and this is not what I meant. 
The intention back then was, scrolling (`scroll-until-text`) using keyboard was 
1. implemented differently, it would scroll the normal way, iirc was by basically pressing `pageUp/Down` just like today's `scroll` 
2. we couldn't scroll the overlaying elements like drop-down menu and stuff
So I modified the function to accept scrolling using mouse, and the intention was, these overlay menus are always smaller and would require scrolling less distance else there's a risk of missing the string.

Anyways, we still have two problems
1. scrolling using keyboard for `scroll-until-text` doesn't actually do `ctrl + f`. [Reported on slack too](https://testdriverai.slack.com/archives/C02M2V66NSC/p1755436211100569)
2. we need to give user the option to modify the [`incrementalDistance`](https://github.com/testdriverai/cli/blob/eaf2ed9a872935bb77e39358c2d97ba5f94db685/agent/lib/commands.js#L577) rn that's not happening, we are only giving them the ability to choose the **max distance to scroll before giving up**.

So with this PR I am trying to make it atleast in parity with `scroll-until-image` so that I can finish updating the docs