### PR TITLE
fix handling for /explore in the prompt

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -1139,21 +1139,8 @@ ${yml}
 
     // Create diff if file exists and content has changed
     let diffResult = null;
-    // console.log("Checking for diff. File exists:", fileExists);
-    // console.log(
-    //   "Content changed:",
-    //   fileExists && existingContent !== regression,
-    // );
-    if (fileExists) {
-      // console.log(
-      //   "Existing content preview:",
-      //   existingContent.substring(0, 100),
-      // );
-      // console.log("New content preview:", regression.substring(0, 100));
-    }
 
     if (fileExists && existingContent !== regression) {
-      // console.log("Creating diff - content has changed");
       const patches = diff.structuredPatch(
         filepath,
         filepath,
@@ -1242,9 +1229,6 @@ ${yml}
           timestamp: endTime,
         });
       }
-      // else {
-      // console.log("No diff result to emit");
-      // }
 
       // Emit file save completion event
       this.emitter.emit(events.file.stop, {

--- a/agent/index.js
+++ b/agent/index.js
@@ -1139,21 +1139,21 @@ ${yml}
 
     // Create diff if file exists and content has changed
     let diffResult = null;
-    console.log("Checking for diff. File exists:", fileExists);
-    console.log(
-      "Content changed:",
-      fileExists && existingContent !== regression,
-    );
+    // console.log("Checking for diff. File exists:", fileExists);
+    // console.log(
+    //   "Content changed:",
+    //   fileExists && existingContent !== regression,
+    // );
     if (fileExists) {
-      console.log(
-        "Existing content preview:",
-        existingContent.substring(0, 100),
-      );
-      console.log("New content preview:", regression.substring(0, 100));
+      // console.log(
+      //   "Existing content preview:",
+      //   existingContent.substring(0, 100),
+      // );
+      // console.log("New content preview:", regression.substring(0, 100));
     }
 
     if (fileExists && existingContent !== regression) {
-      console.log("Creating diff - content has changed");
+      // console.log("Creating diff - content has changed");
       const patches = diff.structuredPatch(
         filepath,
         filepath,
@@ -1241,9 +1241,10 @@ ${yml}
           diff: diffResult,
           timestamp: endTime,
         });
-      } else {
-        console.log("No diff result to emit");
       }
+      // else {
+      // console.log("No diff result to emit");
+      // }
 
       // Emit file save completion event
       this.emitter.emit(events.file.stop, {

--- a/interfaces/readline.js
+++ b/interfaces/readline.js
@@ -110,7 +110,7 @@ class ReadlineInterface {
 
     try {
       // Parse interactive commands (starting with /)
-      if (input.startsWith("/")) {
+      if (input.startsWith("/") && !input.startsWith("/explore")) {
         const parts = input.slice(1).split(" ");
         const commandName = parts[0];
         const args = parts.slice(1);


### PR DESCRIPTION
if the prompt was : `> /explore go to youtube.com` 
it would interpret the "go to youtube.com" as args so they would become ["go", "to", "youtube.com"]

anyways, it was pretty simple fix, mainly due to the fact that every prompt is ran in [exploratory mode](https://github.com/testdriverai/cli/blob/79cbdf520030fee9d05b34b41ecf448e03b48aeb/interfaces/readline.js#L149-L157) other than /run and other meta commands.

Also removed some unnecessary logging, I just commented them out, happy to just remove it as well
 _I guess it was added for debugging sake and wasn't removed later._ 

