### PR TITLE
Emit "test.start" before connection happens

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -1772,11 +1772,10 @@ ${regression}
         theme.green(`Howdy! I'm TestDriver v${packageJson.version}`),
       );
 
-
       // Emit test start event for the entire test execution
       this.emitter.emit(events.test.start, {
         filePath: this.thisFile,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       });
 
       // Start the debugger server as early as possible to ensure event listeners are attached

--- a/agent/index.js
+++ b/agent/index.js
@@ -1771,6 +1771,14 @@ ${regression}
         events.log.log,
         theme.green(`Howdy! I'm TestDriver v${packageJson.version}`),
       );
+
+
+      // Emit test start event for the entire test execution
+      this.emitter.emit(events.test.start, {
+        filePath: this.thisFile,
+        timestamp: Date.now()
+      });
+
       // Start the debugger server as early as possible to ensure event listeners are attached
       if (!debuggerStarted) {
         debuggerStarted = true; // Prevent multiple starts, especially when running test in parallel

--- a/agent/interface.js
+++ b/agent/interface.js
@@ -68,12 +68,6 @@ function createCommandDefinitions(agent) {
         const file = normalizeFilePath(args.file);
         const testStartTime = Date.now();
 
-        // Emit test start event for the entire test execution
-        agent.emitter.emit(events.test.start, {
-          filePath: file,
-          timestamp: testStartTime,
-        });
-
         try {
           await agent.runLifecycle("prerun");
           // When run() is called through run.js CLI command, shouldExit should be true


### PR DESCRIPTION
This solves the issue where connection failures are not rendered in `junit.xml`. This is example output when the server isn not running at all.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites tests="1" failures="1" errors="0" skipped="0">
  <testsuite name="testdriver/edge-cases" tests="1" failures="1" errors="0" skipped="0">
    <testcase classname="testdriver/edge-cases" name="js-promise.yaml" time="0.858">
      <failure message="Failed commands: exec"/>
      <system-out><![CDATA[Starting ****ger server...
This is beta software!
Join our Discord for help
https://discord.com/invite/cWDFW8DzPm
exiting...
running /Users/ianjennings/Development/cli/testdriver/edge-cases/lifecycle/postrun.yaml...

> postrun cleanup
postrun.yaml:4:6 (exec)
exec
command='exec' code='console.log("POSTRUN EXECUTED SUCCESSFULLY!");
console.log("This proves postrun lifecycle ran after ...' lang='js'
calling exec...
console.log("POSTRUN EXECUTED SUCCESSFULLY!");
console.log("This proves postrun lifecycle ran after the error.");

running js...
running value of `windows` in local JS vm...

------
------

No result returned from script
To attempt automatic recovery, re-run with the --heal flag.
reviewing test...
Failed to summarize: Cannot destructure property 'base64' of '(intermediate value)' as it is undefined.
exiting...]]></system-out>
      <system-err><![CDATA[Maximum call stack size exceeded
Error detected, but recovery mode is not enabled.
Error in postrun.yaml:

   3     steps:
   4       - prompt: "postrun cleanup"
   5         commands:
   6 >>>       - command: exec
   7             lang: js
   8             code: |
   9               console.log("POSTRUN EXECUTED SUCCESSFULLY!");

Error: Maximum call stack size exceeded]]></system-err>
    </testcase>
  </testsuite>
</testsuites>
```