### PR TITLE
Add "prompt" command to generate

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -891,7 +891,7 @@ commands:
   // based on the current state of the system (primarily the current screenshot)
   // it will generate files that contain only "prompts"
   // @todo revit the generate command
-  async generate(count = 1) {
+  async generate(count = 1, prompt = null) {
     this.emitter.emit(events.log.debug, `generate called with count: ${count}`);
 
     await this.runLifecycle("prerun");
@@ -909,7 +909,7 @@ commands:
     let message = await this.sdk.req(
       "generate",
       {
-        prompt: "make sure to do a spellcheck",
+        prompt: prompt || "make sure to do a spellcheck",
         image,
         mousePosition: mouse,
         activeWindow: activeWindow,

--- a/agent/interface.js
+++ b/agent/interface.js
@@ -204,10 +204,6 @@ function createCommandDefinitions(agent) {
           description: "Multi-line text prompt describing what to generate",
           required: false,
         }),
-        file: Args.string({
-          description: "Base test file to run before generating (optional)",
-          required: false,
-        }),
       },
       flags: {
         count: Flags.integer({
@@ -231,7 +227,6 @@ function createCommandDefinitions(agent) {
         }),
       },
       handler: async (args, flags) => {
-        // The file argument is already handled by thisFile in the agent constructor
         // Call generate with the count and prompt
         await agent.generate(flags.count || 3, args.prompt);
       },

--- a/agent/interface.js
+++ b/agent/interface.js
@@ -200,6 +200,10 @@ function createCommandDefinitions(agent) {
     generate: {
       description: "Generate test files based on current screen state",
       args: {
+        prompt: Args.string({
+          description: "Multi-line text prompt describing what to generate",
+          required: false,
+        }),
         file: Args.string({
           description: "Base test file to run before generating (optional)",
           required: false,
@@ -228,8 +232,8 @@ function createCommandDefinitions(agent) {
       },
       handler: async (args, flags) => {
         // The file argument is already handled by thisFile in the agent constructor
-        // Just call generate with the count
-        await agent.generate(flags.count || 3);
+        // Call generate with the count and prompt
+        await agent.generate(flags.count || 3, args.prompt);
       },
     },
   };


### PR DESCRIPTION
Prompt Input for `generate` command

```
❯ node bin/testdriverai.js generate --help                                              
Generate test files based on current screen state

USAGE
  $ testdriverai generate [PROMPT] [FILE] [--count <value>] [--headless] [--new] [--sandbox-ami <value>] [--sandbox-instance <value>]

ARGUMENTS
  PROMPT  Multi-line text prompt describing what to generate
  FILE    Base test file to run before generating (optional)

FLAGS
  --count=<value>             [default: 3] Number of test files to generate
  --headless                  Run in headless mode (no GUI)
  --new                       Create a new sandbox instead of reconnecting to an existing one
  --sandbox-ami=<value>       Specify AMI ID for sandbox instance (e.g., ami-1234)
  --sandbox-instance=<value>  Specify EC2 instance type for sandbox (e.g., i3.metal)

DESCRIPTION
  Generate test files based on current screen state
```